### PR TITLE
Fix replay chatview with new gummys

### DIFF
--- a/cockatrice/src/carditem.cpp
+++ b/cockatrice/src/carditem.cpp
@@ -26,6 +26,9 @@ CardItem::CardItem(Player *_owner, const QString &_name, int _cardid, bool _reve
     cardMenu = new QMenu;
     ptMenu = new QMenu;
     moveMenu = new QMenu;
+    addCounterMenu = new QMenu;
+    removeCounterMenu = new QMenu;
+    setCounterMenu = new QMenu;
     
     retranslateUi();
     emit updateCardMenu(this);
@@ -41,6 +44,9 @@ CardItem::~CardItem()
     delete cardMenu;
     delete ptMenu;
     delete moveMenu;
+    delete addCounterMenu;
+    delete removeCounterMenu;
+    delete setCounterMenu;
     
     deleteDragItem();
 }
@@ -82,6 +88,9 @@ void CardItem::retranslateUi()
 {
     moveMenu->setTitle(tr("&Move to"));
     ptMenu->setTitle(tr("&Power / toughness"));
+    addCounterMenu->setTitle(tr("Add Counter"));
+    removeCounterMenu->setTitle(tr("Remove Counter"));
+    setCounterMenu->setTitle(tr("Set Counters"));
 }
 
 void CardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)

--- a/cockatrice/src/carditem.h
+++ b/cockatrice/src/carditem.h
@@ -32,7 +32,7 @@ private:
     CardItem *attachedTo;
     QList<CardItem *> attachedCards;
     
-    QMenu *cardMenu, *ptMenu, *moveMenu;
+    QMenu *cardMenu, *ptMenu, *moveMenu, *addCounterMenu, *removeCounterMenu, *setCounterMenu;
 
     void prepareDelete();
 public slots:
@@ -75,6 +75,9 @@ public:
     QMenu *getCardMenu() const { return cardMenu; }
     QMenu *getPTMenu() const { return ptMenu; }
     QMenu *getMoveMenu() const { return moveMenu; }
+    QMenu *getAddCounterMenu() const { return addCounterMenu; }
+    QMenu *getRemoveCounterMenu() const { return removeCounterMenu; }
+    QMenu *getSetCounterMenu() const { return setCounterMenu; }
     
     bool animationEvent();
     CardDragItem *createDragItem(int _id, const QPointF &_pos, const QPointF &_scenePos, bool faceDown);

--- a/cockatrice/src/chatview.cpp
+++ b/cockatrice/src/chatview.cpp
@@ -122,7 +122,7 @@ void ChatView::appendUrlTag(QTextCursor &cursor, QString url)
     cursor.setCharFormat(oldFormat);
 }
 
-void ChatView::appendMessage(QString message, RoomMessageTypeFlags messageType, QString sender, UserLevelFlags userLevel, bool playerBold)
+void ChatView::appendMessage(QString message, RoomMessageTypeFlags messageType, QString sender, UserLevelFlags userLevel, QString UserPrivLevel, bool playerBold)
 {
     bool atBottom = verticalScrollBar()->value() >= verticalScrollBar()->maximum();
     bool sameSender = (sender == lastSender) && !lastSender.isEmpty();
@@ -159,9 +159,7 @@ void ChatView::appendMessage(QString message, RoomMessageTypeFlags messageType, 
             if (!sender.isEmpty() && tabSupervisor->getUserListsTab()) {
                 const int pixelSize = QFontInfo(cursor.charFormat().font()).pixelSize();
                 QMap<QString, UserListTWI *> buddyList = tabSupervisor->getUserListsTab()->getBuddyList()->getUsers();
-                QMap<QString, UserListTWI *> userList = tabSupervisor->getUserListsTab()->getAllUsersList()->getUsers();
-                UserListTWI *vlu = userList.value(sender);
-                cursor.insertImage(UserLevelPixmapGenerator::generatePixmap(pixelSize, userLevel, buddyList.contains(sender), QString::fromStdString(vlu->getUserInfo().privlevel())).toImage());
+                cursor.insertImage(UserLevelPixmapGenerator::generatePixmap(pixelSize, userLevel, buddyList.contains(sender), UserPrivLevel).toImage());
                 cursor.insertText(" ");
             }
             cursor.setCharFormat(senderFormat);

--- a/cockatrice/src/chatview.h
+++ b/cockatrice/src/chatview.h
@@ -60,7 +60,7 @@ public:
     void retranslateUi();
     void appendHtml(const QString &html);
     void appendHtmlServerMessage(const QString &html, bool optionalIsBold = false, QString optionalFontColor = QString());
-    void appendMessage(QString message, RoomMessageTypeFlags messageType = 0, QString sender = QString(), UserLevelFlags userLevel = UserLevelFlags(), bool playerBold = false);
+    void appendMessage(QString message, RoomMessageTypeFlags messageType = 0, QString sender = QString(), UserLevelFlags userLevel = UserLevelFlags(), QString UserPrivLevel = "NONE", bool playerBold = false);
     void clearChat();
 protected:
     void enterEvent(QEvent *event);

--- a/cockatrice/src/messagelogwidget.cpp
+++ b/cockatrice/src/messagelogwidget.cpp
@@ -124,12 +124,12 @@ void MessageLogWidget::logConnectionStateChanged(Player *player, bool connection
 
 void MessageLogWidget::logSay(Player *player, QString message)
 {
-    appendMessage(message, 0, player->getName(), UserLevelFlags(player->getUserInfo()->user_level()), true);
+    appendMessage(message, 0, player->getName(), UserLevelFlags(player->getUserInfo()->user_level()), QString::fromStdString(player->getUserInfo()->privlevel()), true);
 }
 
-void MessageLogWidget::logSpectatorSay(QString spectatorName, UserLevelFlags spectatorUserLevel, QString message)
+void MessageLogWidget::logSpectatorSay(QString spectatorName, UserLevelFlags spectatorUserLevel, QString userPrivLevel, QString message)
 {
-    appendMessage(message, 0, spectatorName, spectatorUserLevel, false);
+    appendMessage(message, 0, spectatorName, spectatorUserLevel, userPrivLevel, false);
 }
 
 void MessageLogWidget::logShuffle(Player *player, CardZone *zone)

--- a/cockatrice/src/messagelogwidget.h
+++ b/cockatrice/src/messagelogwidget.h
@@ -53,7 +53,7 @@ public slots:
     void logGameStart();
     void logConnectionStateChanged(Player *player, bool connectionState);
     void logSay(Player *player, QString message);
-    void logSpectatorSay(QString spectatorName, UserLevelFlags spectatorUserLevel, QString message);
+    void logSpectatorSay(QString spectatorName, UserLevelFlags spectatorUserLevel, QString userPrivLevel, QString message);
     void logShuffle(Player *player, CardZone *zone);
     void logRollDie(Player *player, int sides, int roll);
     void logDrawCards(Player *player, int number);

--- a/cockatrice/src/player.cpp
+++ b/cockatrice/src/player.cpp
@@ -698,13 +698,13 @@ void Player::retranslateUi()
     counterColors.append(tr("Green"));
 
     for (int i = 0; i < aAddCounter.size(); ++i){
-        aAddCounter[i]->setText(tr("&Add counter (%1)").arg(counterColors[i]));
+        aAddCounter[i]->setText(tr("%1").arg(counterColors[i]));
     }
     for (int i = 0; i < aRemoveCounter.size(); ++i){
-        aRemoveCounter[i]->setText(tr("&Remove counter (%1)").arg(counterColors[i]));
+        aRemoveCounter[i]->setText(tr("%1").arg(counterColors[i]));
     }
     for (int i = 0; i < aSetCounter.size(); ++i){
-        aSetCounter[i]->setText(tr("&Set counters (%1)...").arg(counterColors[i]));
+        aSetCounter[i]->setText(tr("%1...").arg(counterColors[i]));
     }
 
     aMoveToTopLibrary->setText(tr("&Top of library"));
@@ -2294,6 +2294,9 @@ void Player::updateCardMenu(CardItem *card)
     QMenu *cardMenu = card->getCardMenu();
     QMenu *ptMenu = card->getPTMenu();
     QMenu *moveMenu = card->getMoveMenu();
+    QMenu *addCounterMenu = card->getAddCounterMenu();
+    QMenu *removeCounterMenu = card->getRemoveCounterMenu();
+    QMenu *setCountersMenu = card->getSetCounterMenu();
 
     cardMenu->clear();
 
@@ -2378,11 +2381,15 @@ void Player::updateCardMenu(CardItem *card)
                 cardMenu->addMenu(moveMenu);
 
                 for (int i = 0; i < aAddCounter.size(); ++i) {
-                    cardMenu->addSeparator();
-                    cardMenu->addAction(aAddCounter[i]);
-                    cardMenu->addAction(aRemoveCounter[i]);
-                    cardMenu->addAction(aSetCounter[i]);
+                    addCounterMenu->addAction(aAddCounter[i]);
+                    removeCounterMenu->addAction(aRemoveCounter[i]);
+                    setCountersMenu->addAction(aSetCounter[i]);
                 }
+
+                cardMenu->addSeparator();
+                cardMenu->addMenu(addCounterMenu);
+                cardMenu->addMenu(removeCounterMenu);
+                cardMenu->addMenu(setCountersMenu);
                 cardMenu->addSeparator();
             } else if (card->getZone()->getName() == "stack") {
                 cardMenu->addAction(aDrawArrow);

--- a/cockatrice/src/tab_game.cpp
+++ b/cockatrice/src/tab_game.cpp
@@ -880,7 +880,7 @@ void TabGame::closeGame()
 void TabGame::eventSpectatorSay(const Event_GameSay &event, int eventPlayerId, const GameEventContext & /*context*/)
 {
     const ServerInfo_User &userInfo = spectators.value(eventPlayerId);
-    messageLog->logSpectatorSay(QString::fromStdString(userInfo.name()), UserLevelFlags(userInfo.user_level()), QString::fromStdString(event.message()));
+    messageLog->logSpectatorSay(QString::fromStdString(userInfo.name()), UserLevelFlags(userInfo.user_level()), QString::fromStdString(userInfo.privlevel()), QString::fromStdString(event.message()));
 }
 
 void TabGame::eventSpectatorLeave(const Event_Leave & /*event*/, int eventPlayerId, const GameEventContext & /*context*/)

--- a/cockatrice/src/tab_message.cpp
+++ b/cockatrice/src/tab_message.cpp
@@ -115,7 +115,7 @@ void TabMessage::actLeave()
 void TabMessage::processUserMessageEvent(const Event_UserMessage &event)
 {
     const UserLevelFlags userLevel(event.sender_name() == otherUserInfo->name() ? otherUserInfo->user_level() : ownUserInfo->user_level());
-    chatView->appendMessage(QString::fromStdString(event.message()), 0,QString::fromStdString(event.sender_name()), userLevel, true);
+    chatView->appendMessage(QString::fromStdString(event.message()), 0,QString::fromStdString(event.sender_name()), userLevel, QString::fromStdString(otherUserInfo->privlevel()), true);
     if (tabSupervisor->currentIndex() != tabSupervisor->indexOf(this))
         soundEngine->playSound("private_message");
     if (settingsCache->getShowMessagePopup() && shouldShowSystemPopup(event))

--- a/cockatrice/src/tab_room.cpp
+++ b/cockatrice/src/tab_room.cpp
@@ -273,8 +273,10 @@ void TabRoom::processRoomSayEvent(const Event_RoomSay &event)
 
     UserListTWI *twi = userList->getUsers().value(senderName);
     UserLevelFlags userLevel;
+    QString userPrivLevel;
     if (twi) {
         userLevel = UserLevelFlags(twi->getUserInfo().user_level());
+        userPrivLevel = QString::fromStdString(twi->getUserInfo().privlevel());
         if (settingsCache->getIgnoreUnregisteredUsers() && !userLevel.testFlag(ServerInfo_User::IsRegistered))
             return;
     }
@@ -286,7 +288,7 @@ void TabRoom::processRoomSayEvent(const Event_RoomSay &event)
         message = "[" + QString(QDateTime::fromMSecsSinceEpoch(event.time_of()).toLocalTime().toString("d MMM yyyy HH:mm:ss")) + "] " + message;
 
 
-    chatView->appendMessage(message, event.message_type(), senderName, userLevel, true);
+    chatView->appendMessage(message, event.message_type(), senderName, userLevel, userPrivLevel, true);
     emit userEvent(false);
 }
 


### PR DESCRIPTION
Fix #2334
This update fixes the violation that happens when watching replays to
determin the proper user privlevel in order to generate the correct
gummy.